### PR TITLE
Compatibility break

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 prezent/ink-bundle
 ==================
 
+__Using Symfony 2.7 up to 3.2?__  
+Please use v0.1.5 of this bundle. Later versions are not compatible with those versions of Symfony.
+
+
 Easy responsive e-emails using Foundation and Inky
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^5.5|^7.0",
         "hampe/inky": "^1.3",
-        "symfony/framework-bundle": "^2.6|^3.0|^4.0",
+        "symfony/framework-bundle": "^3.3|^4.0",
         "tijsverkoyen/css-to-inline-styles": "^2.2",
         "swiftmailer/swiftmailer": "^5.4|^6.0",
         "symfony/twig-bundle": "^2.6|^3.0|^4.0"

--- a/src/Resources/doc/index.md
+++ b/src/Resources/doc/index.md
@@ -21,6 +21,11 @@ This bundle can be installed using Composer. Tell composer to install the bundle
 $ php composer.phar require prezent/ink-bundle
 ```
 
+For Symfony 2.7 up to 3.2, tell Composer to get v0.1.5 of the Bundle.
+```bash
+$ php composer.phar require prezent/ink-bundle:0.1.5
+```
+
 Then, activate the bundle in your kernel:
 
 ```php


### PR DESCRIPTION
Changes to `Resources/config/services.xml` broke compatibility with Symfony 3.2 and earlier. This PR fixes `composer.json` and the documentation to reflect this break.