### PR TITLE
Fixes for Dependency Injection Symfony 2.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /composer.lock
 /phpunit.xml
 /vendor/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /composer.lock
 /phpunit.xml
 /vendor/
-.idea

--- a/src/Mail/TwigFactory.php
+++ b/src/Mail/TwigFactory.php
@@ -5,7 +5,6 @@ namespace Prezent\InkBundle\Mail;
 use Pelago\Emogrifier;
 use Prezent\Inky\Inky;
 use Symfony\Component\Routing\RequestContext;
-use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
 /**
  * Create e-mail messages from Twig templates
@@ -36,7 +35,7 @@ class TwigFactory
      * @param Inky $inky
      * @param CssToInlineStyles $inliner
      */
-    public function __construct(\Twig_Environment $twig, Inky $inky, CssToInlineStyles $inliner)
+    public function __construct(\Twig_Environment $twig, Inky $inky, Emogrifier $inliner)
     {
         $this->twig = $twig;
         $this->inky = $inky;

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -15,8 +15,8 @@
             <tag name="prezent_ink.inky_component" />
         </service>
 
-        <service id="Prezent\Inky\Inky" />
-        <service id="Pelago\Emogrifier"/>
+        <service id="prezent_ink.inky" class="Prezent\Inky\Inky" />
+        <service id="prezent_ink.inliner" class="Pelago\Emogrifier"/>
 
     </services>
 </container>


### PR DESCRIPTION
Service Definition is broken on the 0.1.x-Branch; services are missing or classes that are no longer defined are being type-hinted.

This PR restores the service definitions and type-hints to be able to use this bundle in Symfony 2.8.