### PR TITLE
Fallback to Text-Only mail if LibXML < 2.7.8 is being used

### DIFF
--- a/src/Mail/TwigFactory.php
+++ b/src/Mail/TwigFactory.php
@@ -53,8 +53,12 @@ class TwigFactory
         $message = new \Swift_Message();
         $message
             ->setSubject($template->renderBlock('subject', $parameters))
-            ->setBody($this->renderTextPart($template, $parameters), 'text/plain')
-            ->addPart($this->renderHtmlPart($template, $parameters), 'text/html');
+            ->setBody($this->renderTextPart($template, $parameters), 'text/plain');
+
+        if(defined('LIBXML_HTML_NOIMPLIED') && defined('LIBXML_HTML_NODEFDTD')) {
+            $message
+                ->addPart($this->renderHtmlPart($template, $parameters), 'text/html');
+        }
 
         return $message;
     }


### PR DESCRIPTION
Fixes issue #4; if the constants `LIBXML_HTML_NOIMPLIED` and `LIBXML_HTML_NODEFDTD` are not defined, the bundle will no longer add the HTML-part; which cannot be generated by Prezent/prezent-inky when these constants are missing.

Please also cherry-pick to 0.1.x